### PR TITLE
fixed movement input and made paths cross os-supported

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,5 +1,6 @@
 from tkinter import *
 import sys
+import os
 
 def start():
     global iMobs
@@ -35,9 +36,9 @@ def init(width , height , title):
     window.title(title)
     canvas= Canvas(window,width=width,height=height,bg="black")
     canvas.grid(column=0,row=0)
-    shootImage = PhotoImage(file = "imgs\\s.png")
-    window.bind_all("<Left>", left)
-    window.bind_all("<Right>", right)
+    shootImage = PhotoImage(file = os.path.join("imgs","s.png"))
+    window.bind_all("<KeyPress>", keypressed)
+    window.bind_all("<KeyRelease>", keyreleased)
 
 def create_Mob(image, spawnRate = 1):
     iMobs.append([image, spawnRate])
@@ -72,19 +73,23 @@ def Pmove(x,y):
         canvas.coords(player,Ppos[0],Ppos[1])
 
 
+def keypressed(arg):
+	global r
+	global l
+	
+	if arg.keysym == 'Left':
+		l = 1
+	elif arg.keysym == 'Right':
+		r = 1
 
-
-def right(arg):
-    global r
-    r = 1
-#    global Ppos
-#    Pmove(Ppos[0]+10,Ppos[1])
-def left(arg):
-    global l
-    l = 1
-#    global Ppos
-#    Pmove(Ppos[0]-10,Ppos[1])
-
+def keyreleased(arg):
+	global r
+	global l
+	
+	if arg.keysym == 'Left':
+		l = 0
+	elif arg.keysym == 'Right':
+		r = 0
 
 def shoot(Ppos):
     x=Ppos[0]+15
@@ -143,7 +148,6 @@ def update():
     if r ==1 :
         if ri < 10:
             ri += 2
-        r = 0
     else:
         if ri > 0 and step%5 == 0:
             ri -=2
@@ -151,7 +155,6 @@ def update():
     if l==1:
         if le < 10:
             le += 2
-        l=0
     else :
         if le > 0 and step%5 == 0:
             le -=2

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from tkinter import *
 from game import *
-
+import os
 
 
 
@@ -9,9 +9,9 @@ from game import *
 
 init(800,600,"space colonizer")
 
-image = PhotoImage(file = "imgs\\p.png")
+image = PhotoImage(file = os.path.join("imgs","p.png"))
 create_player(400,500,image)
-i = PhotoImage(file = "imgs\\e.png")
+i = PhotoImage(file = os.path.join("imgs","e.png"))
 create_Mob(i)
 
 


### PR DESCRIPTION
Seems like the problem is you where relying on the keyboard spam to change the r and l variables. if you hold any key down you'll see it print once, wait, then spam afterwards. This creates the delay when you hit a wall and try to reverse direction. I fixed it by permanately setting l/r to 1 during a 'keypress' event, and setting them back to 0 following a 'keyrelease' event

Also I changed your hard coded paths (work on windows, not on linux) to os.path.join's (work on windows and linux).

Cheers!
Batch (aka Steven Proctor, a college student looking for practice)